### PR TITLE
Adding support for VS2019

### DIFF
--- a/src/CloudNimble.PackageReferenceUpgrader/source.extension.vsixmanifest
+++ b/src/CloudNimble.PackageReferenceUpgrader/source.extension.vsixmanifest
@@ -10,7 +10,9 @@
         <Tags>web.config, assembly binding redirects, binding redirects, assembly binding</Tags>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,16.0)" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,17.0)" />
+        <InstallationTarget Version="[15.0,17.0)" Id="Microsoft.VisualStudio.Pro" />
+        <InstallationTarget Version="[15.0,17.0)" Id="Microsoft.VisualStudio.Enterprise" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />


### PR DESCRIPTION
I've increased the range for VS Community to include 2019, and also added VS Pro and VS Enterprise with the matching range.