### PR TITLE
Fix installation for VS2019

### DIFF
--- a/src/CloudNimble.PackageReferenceUpgrader/source.extension.cs
+++ b/src/CloudNimble.PackageReferenceUpgrader/source.extension.cs
@@ -9,9 +9,9 @@ namespace CloudNimble.PackageReferenceUpgrader
     {
         public const string Id = "bae2a4ae-be17-4f34-be32-f7f103918589";
         public const string Name = "NuGet PackageReference Upgrader";
-        public const string Description = @"A VS2017 Extension that helps legacy apps migrate off of packages.config. ";
+        public const string Description = @"A VS Extension that helps legacy apps migrate off of packages.config.";
         public const string Language = "en-US";
-        public const string Version = "1.0";
+        public const string Version = "1.0.2";
         public const string Author = "Robert McLaws";
         public const string Tags = "web.config, assembly binding redirects, binding redirects, assembly binding";
     }

--- a/src/CloudNimble.PackageReferenceUpgrader/source.extension.vsixmanifest
+++ b/src/CloudNimble.PackageReferenceUpgrader/source.extension.vsixmanifest
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="bae2a4ae-be17-4f34-be32-f7f103918589" Version="1.0.0" Language="en-US" Publisher="Robert McLaws" />
+        <Identity Id="bae2a4ae-be17-4f34-be32-f7f103918589" Version="1.0.2" Language="en-US" Publisher="Robert McLaws" />
         <DisplayName>NuGet PackageReference Upgrader</DisplayName>
-        <Description xml:space="preserve">A VS2017 Extension that helps legacy apps migrate off of packages.config. </Description>
+        <Description xml:space="preserve">A VS Extension that helps legacy apps migrate off of packages.config.</Description>
         <License>Resources\LICENSE</License>
         <Icon>Resources\Icon.png</Icon>
         <PreviewImage>Resources\Preview.png</PreviewImage>
@@ -18,7 +18,7 @@
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
     </Dependencies>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,17.0)" DisplayName="Visual Studio core editor" />
     </Prerequisites>
     <Assets>
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />


### PR DESCRIPTION
Fix installation for VS 2019.
Addendum to #13
Fixes #12

![image](https://github.com/CloudNimble/PackageReferenceUpgrader/assets/905878/23cfa3b6-8282-4556-819f-c53be085e71d)

To load this extension, we need to allow synchronous autoload:
https://learn.microsoft.com/en-us/visualstudio/extensibility/synchronously-autoloaded-extensions?view=vs-2022

> VS options dialog -> Environment -> Extensions -> check `Allow synchronous autoload of extensions`